### PR TITLE
Experiment: remove context

### DIFF
--- a/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ActivityLifecycleComposeAdapter.kt
+++ b/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ActivityLifecycleComposeAdapter.kt
@@ -24,34 +24,34 @@ public class ActivityLifecycleComposeAdapter(
 ) : DefaultLifecycleObserver {
 
   override fun onStart(owner: ActivityLifecycleOwner) {
-    navigable.show(context)
+    navigable.show()
   }
 
   override fun onResume(owner: ActivityLifecycleOwner) {
-    navigable.resume(context)
+    navigable.resume()
   }
 
   override fun onPause(owner: ActivityLifecycleOwner) {
-    navigable.pause(context)
+    navigable.pause()
   }
 
   override fun onStop(owner: ActivityLifecycleOwner) {
-    navigable.hide(context)
+    navigable.hide()
   }
 
   override fun onDestroy(owner: ActivityLifecycleOwner) {
     if (context.isFinishing) {
-      navigable.destroy(context.applicationContext)
+      navigable.destroy()
     }
   }
 }
 
 public fun ComponentActivity.setContentNavigable(navigable: Navigable<@Composable () -> Unit>) {
   if (navigable is LifecycleOwner && navigable.currentState == Destroyed) {
-    navigable.create(applicationContext)
+    navigable.create()
   }
   if (adapterMap.containsKey(navigable)) {
-    navigable.detachAndRemoveFromStaticMap(applicationContext)
+    navigable.detachAndRemoveFromStaticMap()
   }
   val lifecycleAdapter = ActivityLifecycleComposeAdapter(navigable, this)
   navigable.attachAndAddToStaticMap(lifecycleAdapter, lifecycle)
@@ -66,13 +66,11 @@ private fun Navigable<@Composable () -> Unit>.attachAndAddToStaticMap(
   adapterMap = adapterMap + (this to (lifecycleAdapter to lifecycle))
 }
 
-private fun Navigable<@Composable () -> Unit>.detachAndRemoveFromStaticMap(
-  applicationContext: Context
-) {
+private fun Navigable<@Composable () -> Unit>.detachAndRemoveFromStaticMap() {
   val (lifecycleAdapter, lifecycle) = adapterMap[this]!!
   lifecycle.removeObserver(lifecycleAdapter)
-  if (this is LifecycleOwner && currentState !is Created) {
-    transition(this.currentState, Created(applicationContext))
+  if (this is LifecycleOwner && currentState != Created) {
+    transition(this.currentState, Created)
   }
   adapterMap = adapterMap - this
 }

--- a/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ActivityLifecycleComposeAdapter.kt
+++ b/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ActivityLifecycleComposeAdapter.kt
@@ -1,7 +1,6 @@
 package com.ryanmoelter.magellanx.compose
 
 import android.app.Activity
-import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable

--- a/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ComposeExtensions.kt
+++ b/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ComposeExtensions.kt
@@ -33,8 +33,8 @@ public fun LifecycleOwner.WhenShown(Content: @Composable () -> Unit) {
     currentStateFlow
       .map { lifecycleState ->
         when (lifecycleState) {
-          is Destroyed, is Created -> false
-          is Shown, is Resumed -> true
+          Destroyed, Created -> false
+          Shown, Resumed -> true
         }
       }
   }

--- a/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/navigation/ComposeNavigator.kt
+++ b/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/navigation/ComposeNavigator.kt
@@ -96,7 +96,7 @@ public open class ComposeNavigator : LifecycleAwareComponent(), Displayable<@Com
     }
   }
 
-  override fun onDestroy(context: Context) {
+  override fun onDestroy() {
     backStack
       .map { it.navigable }
       .forEach { lifecycleRegistry.removeFromLifecycle(it) }

--- a/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/navigation/ComposeNavigator.kt
+++ b/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/navigation/ComposeNavigator.kt
@@ -1,7 +1,6 @@
 @file:Suppress("ForbiddenComment")
 package com.ryanmoelter.magellanx.compose.navigation
 
-import android.content.Context
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.Box

--- a/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/navigation/ComposeNavigator.kt
+++ b/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/navigation/ComposeNavigator.kt
@@ -25,7 +25,6 @@ import com.ryanmoelter.magellanx.core.lifecycle.LifecycleLimit
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 
-@OptIn(ExperimentalAnimationApi::class)
 public open class ComposeNavigator : LifecycleAwareComponent(), Displayable<@Composable () -> Unit> {
 
   /**
@@ -66,6 +65,7 @@ public open class ComposeNavigator : LifecycleAwareComponent(), Displayable<@Com
     val currentTransitionSpec by transitionFlow.collectAsState()
     val currentDirection by directionFlow.collectAsState()
 
+    @OptIn(ExperimentalAnimationApi::class)
     AnimatedContent(
       targetState = currentNavigable,
       transitionSpec = currentTransitionSpec.getTransitionForDirection(currentDirection)
@@ -206,7 +206,6 @@ public open class ComposeNavigator : LifecycleAwareComponent(), Displayable<@Com
   public open fun atRoot(): Boolean = backStack.size <= 1
 }
 
-@ExperimentalAnimationApi
 public data class ComposeNavigationEvent(
   val navigable: Navigable<@Composable () -> Unit>,
   val transitionSpec: MagellanComposeTransition

--- a/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/transitions/BuiltInTransitionSpecs.kt
+++ b/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/transitions/BuiltInTransitionSpecs.kt
@@ -16,23 +16,24 @@ import com.ryanmoelter.magellanx.compose.navigation.Direction
 import com.ryanmoelter.magellanx.core.Navigable
 import kotlin.math.roundToInt
 
-@OptIn(ExperimentalAnimationApi::class)
 public interface MagellanComposeTransition {
 
   @Composable
+  @OptIn(ExperimentalAnimationApi::class)
   public fun getTransitionForDirection(
     direction: Direction
   ): AnimatedContentScope<Navigable<@Composable () -> Unit>?>.() -> ContentTransform
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 public class SimpleComposeTransition(
+  @OptIn(ExperimentalAnimationApi::class)
   /* ktlint-disable max-line-length */
   public val transitionSpec: AnimatedContentScope<Navigable<@Composable () -> Unit>?>.(Direction) -> ContentTransform
   /* ktlint-enable max-line-length */
 ) : MagellanComposeTransition {
 
   @Composable
+  @OptIn(ExperimentalAnimationApi::class)
   public override fun getTransitionForDirection(
     direction: Direction
   ): AnimatedContentScope<Navigable<@Composable () -> Unit>?>.() -> ContentTransform {
@@ -44,7 +45,7 @@ private const val SCALE_DOWN_FACTOR = 0.85f
 private const val SCALE_UP_FACTOR = 1.15f
 
 @OptIn(ExperimentalAnimationApi::class)
-public val defaultTransition: SimpleComposeTransition = SimpleComposeTransition {
+public val defaultTransition: MagellanComposeTransition = SimpleComposeTransition {
   when (it) {
     Direction.FORWARD -> {
       fadeIn() + scaleIn(initialScale = SCALE_DOWN_FACTOR) with
@@ -60,7 +61,7 @@ public val defaultTransition: SimpleComposeTransition = SimpleComposeTransition 
 private const val HEIGHT_OFFSET_FACTOR = 0.8f
 
 @OptIn(ExperimentalAnimationApi::class)
-public val showTransition: SimpleComposeTransition = SimpleComposeTransition { direction ->
+public val showTransition: MagellanComposeTransition = SimpleComposeTransition { direction ->
   when (direction) {
     Direction.FORWARD -> {
       fadeIn() +
@@ -81,6 +82,6 @@ public val showTransition: SimpleComposeTransition = SimpleComposeTransition { d
 }
 
 @OptIn(ExperimentalAnimationApi::class)
-public val noTransition: SimpleComposeTransition = SimpleComposeTransition {
+public val noTransition: MagellanComposeTransition = SimpleComposeTransition {
   EnterTransition.None with ExitTransition.None
 }

--- a/magellanx-core/build.gradle.kts
+++ b/magellanx-core/build.gradle.kts
@@ -71,8 +71,6 @@ dependencies {
 
   // Testing
   testImplementation(libs.kotest.assertions.core)
-  testImplementation(libs.kotest.extensions.robolectric)
-  testImplementation(libs.robolectric)
   testImplementation(libs.androidx.test.core)
   testImplementation(libs.androidx.test.core.ktx)
   testImplementation("org.mockito:mockito-core:4.3.1")

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/coroutines/CreatedLifecycleScope.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/coroutines/CreatedLifecycleScope.kt
@@ -1,6 +1,5 @@
 package com.ryanmoelter.magellanx.core.coroutines
 
-import android.content.Context
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleAware
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/coroutines/CreatedLifecycleScope.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/coroutines/CreatedLifecycleScope.kt
@@ -19,11 +19,11 @@ public class CreatedLifecycleScope : LifecycleAware, CoroutineScope {
   override var coroutineContext: CoroutineContext = job + Dispatchers.Main
     private set
 
-  override fun create(context: Context) {
+  override fun create() {
     job = SupervisorJob()
   }
 
-  override fun destroy(context: Context) {
+  override fun destroy() {
     job.cancel(CancellationException("Destroyed"))
   }
 }

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/coroutines/ShownLifecycleScope.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/coroutines/ShownLifecycleScope.kt
@@ -19,11 +19,11 @@ public class ShownLifecycleScope : LifecycleAware, CoroutineScope {
   override var coroutineContext: CoroutineContext = job + Dispatchers.Main
     private set
 
-  override fun show(context: Context) {
+  override fun show() {
     job = SupervisorJob()
   }
 
-  override fun hide(context: Context) {
+  override fun hide() {
     job.cancel(CancellationException("Hidden"))
   }
 }

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/coroutines/ShownLifecycleScope.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/coroutines/ShownLifecycleScope.kt
@@ -1,6 +1,5 @@
 package com.ryanmoelter.magellanx.core.coroutines
 
-import android.content.Context
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleAware
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/debug/StatePrinter.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/debug/StatePrinter.kt
@@ -56,10 +56,10 @@ private fun LifecycleAware.getLifecycleStateSnapshotRecursive(
 }
 
 private fun LifecycleOwner.describeSelf(indent: String): String =
-  "$indent${this::class.java.simpleName} (${currentState::class.java.simpleName})\n"
+  "$indent${this::class.java.simpleName} (${currentState.name})\n"
 
 private fun LifecycleAware.describeSelf(
   indent: String,
   parentLifecycleState: LifecycleState
 ): String =
-  "$indent${this::class.java.simpleName} (${parentLifecycleState::class.java.simpleName}?)\n"
+  "$indent${this::class.java.simpleName} (${parentLifecycleState.name}?)\n"

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/CreateAndAttachFieldToLifecycleWhenShownDelegate.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/CreateAndAttachFieldToLifecycleWhenShownDelegate.kt
@@ -1,7 +1,5 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-import android.content.Context
-
 public class CreateAndAttachFieldToLifecycleWhenShownDelegate<Field>(
   public val fieldSupplier: () -> Field
 ) : LifecycleAware {

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/CreateAndAttachFieldToLifecycleWhenShownDelegate.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/CreateAndAttachFieldToLifecycleWhenShownDelegate.kt
@@ -3,23 +3,23 @@ package com.ryanmoelter.magellanx.core.lifecycle
 import android.content.Context
 
 public class CreateAndAttachFieldToLifecycleWhenShownDelegate<Field>(
-  public val fieldSupplier: (Context) -> Field
+  public val fieldSupplier: () -> Field
 ) : LifecycleAware {
 
   public var field: Field? = null
     protected set
 
-  override fun show(context: Context) {
-    field = fieldSupplier(context)
+  override fun show() {
+    field = fieldSupplier()
   }
 
-  override fun hide(context: Context) {
+  override fun hide() {
     field = null
   }
 }
 
 public fun <Field> LifecycleOwner.createAndAttachFieldToLifecycleWhenShown(
-  fieldSupplier: (Context) -> Field
+  fieldSupplier: () -> Field
 ): AttachFieldToLifecycleDelegate<CreateAndAttachFieldToLifecycleWhenShownDelegate<Field>, Field?> =
   attachFieldToLifecycle(
     CreateAndAttachFieldToLifecycleWhenShownDelegate(fieldSupplier),

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleAware.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleAware.kt
@@ -1,13 +1,11 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-import android.content.Context
-
 public interface LifecycleAware {
-  public fun create(context: Context) {}
-  public fun show(context: Context) {}
-  public fun resume(context: Context) {}
-  public fun pause(context: Context) {}
-  public fun hide(context: Context) {}
-  public fun destroy(context: Context) {}
+  public fun create() {}
+  public fun show() {}
+  public fun resume() {}
+  public fun pause() {}
+  public fun hide() {}
+  public fun destroy() {}
   public fun backPressed(): Boolean = false
 }

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleAwareComponent.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleAwareComponent.kt
@@ -13,70 +13,70 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
   override val currentStateFlow: StateFlow<LifecycleState>
     get() = lifecycleRegistry.currentStateFlow
 
-  final override fun create(context: Context) {
-    if (currentState !is LifecycleState.Destroyed) {
+  final override fun create() {
+    if (currentState != LifecycleState.Destroyed) {
       throw IllegalStateException(
         "Cannot create() from a state that is not Destroyed: " +
           "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
-    lifecycleRegistry.create(context)
-    onCreate(context)
+    lifecycleRegistry.create()
+    onCreate()
   }
 
-  final override fun show(context: Context) {
-    if (currentState !is LifecycleState.Created) {
+  final override fun show() {
+    if (currentState != LifecycleState.Created) {
       throw IllegalStateException(
         "Cannot show() from a state that is not Created: " +
           "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
-    lifecycleRegistry.show(context)
-    onShow(context)
+    lifecycleRegistry.show()
+    onShow()
   }
 
-  final override fun resume(context: Context) {
-    if (currentState !is LifecycleState.Shown) {
+  final override fun resume() {
+    if (currentState != LifecycleState.Shown) {
       throw IllegalStateException(
         "Cannot resume() from a state that is not Shown: " +
           "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
-    lifecycleRegistry.resume(context)
-    onResume(context)
+    lifecycleRegistry.resume()
+    onResume()
   }
 
-  final override fun pause(context: Context) {
-    if (currentState !is LifecycleState.Resumed) {
+  final override fun pause() {
+    if (currentState != LifecycleState.Resumed) {
       throw IllegalStateException(
         "Cannot pause() from a state that is not Resumed: " +
           "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
-    onPause(context)
-    lifecycleRegistry.pause(context)
+    onPause()
+    lifecycleRegistry.pause()
   }
 
-  final override fun hide(context: Context) {
-    if (currentState !is LifecycleState.Shown) {
+  final override fun hide() {
+    if (currentState != LifecycleState.Shown) {
       throw IllegalStateException(
         "Cannot hide() from a state that is not Shown: " +
           "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
-    onHide(context)
-    lifecycleRegistry.hide(context)
+    onHide()
+    lifecycleRegistry.hide()
   }
 
-  final override fun destroy(context: Context) {
-    if (currentState !is LifecycleState.Created) {
+  final override fun destroy() {
+    if (currentState != LifecycleState.Created) {
       throw IllegalStateException(
         "Cannot destroy() from a state that is not Created: " +
           "${this::class.java.simpleName} is ${currentState::class.java.simpleName}"
       )
     }
-    onDestroy(context)
-    lifecycleRegistry.destroy(context)
+    onDestroy()
+    lifecycleRegistry.destroy()
   }
 
   override fun backPressed(): Boolean {
@@ -99,17 +99,17 @@ public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {
     lifecycleRegistry.removeFromLifecycle(lifecycleAware, detachedState)
   }
 
-  protected open fun onCreate(context: Context) {}
+  protected open fun onCreate() {}
 
-  protected open fun onShow(context: Context) {}
+  protected open fun onShow() {}
 
-  protected open fun onResume(context: Context) {}
+  protected open fun onResume() {}
 
-  protected open fun onPause(context: Context) {}
+  protected open fun onPause() {}
 
-  protected open fun onHide(context: Context) {}
+  protected open fun onHide() {}
 
-  protected open fun onDestroy(context: Context) {}
+  protected open fun onDestroy() {}
 
   protected open fun onBackPressed(): Boolean = false
 }

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleAwareComponent.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleAwareComponent.kt
@@ -1,6 +1,5 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-import android.content.Context
 import kotlinx.coroutines.flow.StateFlow
 
 public abstract class LifecycleAwareComponent : LifecycleAware, LifecycleOwner {

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleRegistry.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleRegistry.kt
@@ -91,27 +91,27 @@ public class LifecycleRegistry : LifecycleAware, LifecycleOwner {
     }
   }
 
-  override fun create(context: Context) {
-    currentState = LifecycleState.Created(context.applicationContext)
+  override fun create() {
+    currentState = LifecycleState.Created
   }
 
-  override fun show(context: Context) {
-    currentState = LifecycleState.Shown(context)
+  override fun show() {
+    currentState = LifecycleState.Shown
   }
 
-  override fun resume(context: Context) {
-    currentState = LifecycleState.Resumed(context)
+  override fun resume() {
+    currentState = LifecycleState.Resumed
   }
 
-  override fun pause(context: Context) {
-    currentState = LifecycleState.Shown(context)
+  override fun pause() {
+    currentState = LifecycleState.Shown
   }
 
-  override fun hide(context: Context) {
-    currentState = LifecycleState.Created(context.applicationContext)
+  override fun hide() {
+    currentState = LifecycleState.Created
   }
 
-  override fun destroy(context: Context) {
+  override fun destroy() {
     currentState = LifecycleState.Destroyed
   }
 
@@ -136,12 +136,12 @@ private fun LifecycleState.limitBy(limit: LifecycleLimit): LifecycleState =
   if (isWithinLimit(limit)) {
     this
   } else {
-    limit.getMaxLifecycleState(context!!)
+    limit.getMaxLifecycleState()
   }
 
-private fun LifecycleLimit.getMaxLifecycleState(context: Context): LifecycleState = when (this) {
+private fun LifecycleLimit.getMaxLifecycleState(): LifecycleState = when (this) {
   DESTROYED -> LifecycleState.Destroyed
-  CREATED -> LifecycleState.Created(context)
-  SHOWN -> LifecycleState.Shown(context)
-  NO_LIMIT -> LifecycleState.Resumed(context)
+  CREATED -> LifecycleState.Created
+  SHOWN -> LifecycleState.Shown
+  NO_LIMIT -> LifecycleState.Resumed
 }

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleRegistry.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleRegistry.kt
@@ -1,6 +1,5 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-import android.content.Context
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleLimit.CREATED
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleLimit.DESTROYED
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleLimit.NO_LIMIT

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleState.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleState.kt
@@ -1,21 +1,12 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-import android.annotation.SuppressLint
-import android.content.Context
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleStateDirection.BACKWARDS
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleStateDirection.FORWARD
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleStateDirection.NO_MOVEMENT
 
-public sealed class LifecycleState(
-  public open val context: Context? = null,
-  internal val order: Int
-) {
+public enum class LifecycleState(internal val order: Int) {
 
-  @SuppressLint("StaticFieldLeak")
-  public object Destroyed : LifecycleState(null, 0)
-  public data class Created(override val context: Context) : LifecycleState(context, 1)
-  public data class Shown(override val context: Context) : LifecycleState(context, 2)
-  public data class Resumed(override val context: Context) : LifecycleState(context, 3)
+  Destroyed(0), Created(1), Shown(2), Resumed(3);
 
   internal fun getDirectionForMovement(other: LifecycleState) = when {
     order > other.order -> BACKWARDS
@@ -24,11 +15,6 @@ public sealed class LifecycleState(
     else -> throw IllegalStateException(
       "Unhandled order comparison: this is $order and other is ${other.order}"
     )
-  }
-
-  internal fun getEarlierOfCurrentState(): LifecycleState = when (this) {
-    is Destroyed -> Destroyed
-    is Created, is Shown, is Resumed -> Created(context!!)
   }
 }
 

--- a/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleTransitionExtensions.kt
+++ b/magellanx-core/src/main/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleTransitionExtensions.kt
@@ -1,6 +1,5 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-import android.content.Context
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Created
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Destroyed
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Resumed
@@ -23,8 +22,8 @@ public fun Iterable<LifecycleAware>.transition(oldState: LifecycleState, newStat
   var currentState = oldState
   while (currentState.order != newState.order) {
     currentState = when (currentState.getDirectionForMovement(newState)) {
-      FORWARD -> next(this, currentState, newState.context!!)
-      BACKWARDS -> previous(this, currentState, oldState.context!!)
+      FORWARD -> next(this, currentState)
+      BACKWARDS -> previous(this, currentState)
       NO_MOVEMENT -> throw IllegalStateException(
         "Attempting to transition from $currentState to $newState"
       )
@@ -34,23 +33,22 @@ public fun Iterable<LifecycleAware>.transition(oldState: LifecycleState, newStat
 
 private fun next(
   subjects: Iterable<LifecycleAware>,
-  currentState: LifecycleState,
-  context: Context
+  currentState: LifecycleState
 ): LifecycleState {
   return when (currentState) {
-    is Destroyed -> {
-      subjects.forEach { it.create(context.applicationContext) }
-      Created(context.applicationContext)
+    Destroyed -> {
+      subjects.forEach { it.create() }
+      Created
     }
-    is Created -> {
-      subjects.forEach { it.show(context) }
-      Shown(context)
+    Created -> {
+      subjects.forEach { it.show() }
+      Shown
     }
-    is Shown -> {
-      subjects.forEach { it.resume(context) }
-      Resumed(context)
+    Shown -> {
+      subjects.forEach { it.resume() }
+      Resumed
     }
-    is Resumed -> {
+    Resumed -> {
       throw IllegalStateException("Cannot go forward from resumed")
     }
   }
@@ -58,24 +56,23 @@ private fun next(
 
 private fun previous(
   subjects: Iterable<LifecycleAware>,
-  currentState: LifecycleState,
-  context: Context
+  currentState: LifecycleState
 ): LifecycleState {
   return when (currentState) {
-    is Destroyed -> {
+    Destroyed -> {
       throw IllegalStateException("Cannot go backward from destroyed")
     }
-    is Created -> {
-      subjects.forEach { it.destroy(context.applicationContext) }
+    Created -> {
+      subjects.forEach { it.destroy() }
       Destroyed
     }
-    is Shown -> {
-      subjects.forEach { it.hide(context) }
-      Created(context.applicationContext)
+    Shown -> {
+      subjects.forEach { it.hide() }
+      Created
     }
-    is Resumed -> {
-      subjects.forEach { it.pause(context) }
-      Shown(context)
+    Resumed -> {
+      subjects.forEach { it.pause() }
+      Shown
     }
   }
 }

--- a/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/coroutines/ShownLifecycleScopeTest.kt
+++ b/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/coroutines/ShownLifecycleScopeTest.kt
@@ -1,8 +1,5 @@
 package com.ryanmoelter.magellanx.core.coroutines
 
-import android.app.Application
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Created
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Destroyed
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Resumed
@@ -19,15 +16,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 @OptIn(ExperimentalCoroutinesApi::class, InternalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
 internal class ShownLifecycleScopeTest {
 
   private lateinit var shownScope: ShownLifecycleScope
-  private val context: Context = getApplicationContext<Application>()
 
   @Before
   fun setUp() {
@@ -37,17 +30,17 @@ internal class ShownLifecycleScopeTest {
   @Test
   fun cancelBeforeCreated() {
     runTest {
-      shownScope.transition(Destroyed, Created(context))
+      shownScope.transition(Destroyed, Created)
 
       val async = shownScope.async(Dispatchers.Default) { delay(5000) }
       async.isCancelled.shouldBeTrue()
       async.getCancellationException().message shouldContain "Not shown yet"
 
-      shownScope.transition(Created(context), Resumed(context))
+      shownScope.transition(Created, Resumed)
 
       async.isCancelled.shouldBeTrue()
 
-      shownScope.transition(Resumed(context), Created(context))
+      shownScope.transition(Resumed, Created)
 
       async.isCancelled.shouldBeTrue()
       async.getCancellationException().message shouldContain "Not shown yet"
@@ -57,16 +50,16 @@ internal class ShownLifecycleScopeTest {
   @Test
   fun cancelAfterShown() {
     runTest {
-      shownScope.transition(Destroyed, Shown(context))
+      shownScope.transition(Destroyed, Shown)
 
       val async = shownScope.async(Dispatchers.Default) { delay(5000) }
       async.isCancelled.shouldBeFalse()
 
-      shownScope.transition(Shown(context), Resumed(context))
+      shownScope.transition(Shown, Resumed)
 
       async.isCancelled.shouldBeFalse()
 
-      shownScope.transition(Resumed(context), Created(context))
+      shownScope.transition(Resumed, Created)
 
       async.isCancelled.shouldBeTrue()
       async.getCancellationException().message shouldContain "Hidden"
@@ -76,19 +69,19 @@ internal class ShownLifecycleScopeTest {
   @Test
   fun cancelMultipleAfterShown() {
     runTest {
-      shownScope.transition(Destroyed, Shown(context))
+      shownScope.transition(Destroyed, Shown)
 
       val async = shownScope.async(Dispatchers.Default) { delay(5000) }
       val async2 = shownScope.async(Dispatchers.Default) { delay(5000) }
       async.isCancelled.shouldBeFalse()
       async2.isCancelled.shouldBeFalse()
 
-      shownScope.transition(Shown(context), Resumed(context))
+      shownScope.transition(Shown, Resumed)
 
       async.isCancelled.shouldBeFalse()
       async2.isCancelled.shouldBeFalse()
 
-      shownScope.transition(Resumed(context), Created(context))
+      shownScope.transition(Resumed, Created)
 
       async.isCancelled.shouldBeTrue()
       async.getCancellationException().message shouldContain "Hidden"
@@ -100,12 +93,12 @@ internal class ShownLifecycleScopeTest {
   @Test
   fun cancelAfterResumed() {
     runTest {
-      shownScope.transition(Destroyed, Resumed(context))
+      shownScope.transition(Destroyed, Resumed)
 
       val async = shownScope.async(Dispatchers.Default) { delay(5000) }
       async.isCancelled.shouldBeFalse()
 
-      shownScope.transition(Resumed(context), Created(context))
+      shownScope.transition(Resumed, Created)
 
       async.isCancelled.shouldBeTrue()
       async.getCancellationException().message shouldContain "Hidden"

--- a/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/debug/StatePrinterTest.kt
+++ b/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/debug/StatePrinterTest.kt
@@ -1,29 +1,21 @@
 package com.ryanmoelter.magellanx.core.debug
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleAware
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleAwareComponent
 import io.kotest.matchers.shouldBe
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.MockitoAnnotations.openMocks
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 public class StatePrinterTest {
 
   private lateinit var root: LifecycleAwareComponent
-  private lateinit var context: Context
-
   private lateinit var mockSession: AutoCloseable
 
   @Before
   public fun setUp() {
     mockSession = openMocks(this)
-    context = getApplicationContext()
     root = DummyLifecycleOwner()
   }
 
@@ -51,8 +43,8 @@ public class StatePrinterTest {
   public fun multipleChildren() {
     root.attachToLifecycle(MyStep())
     root.attachToLifecycle(MyStep())
-    root.create(context)
-    root.show(context)
+    root.create()
+    root.show()
 
     root.getLifecycleStateSnapshot() shouldBe """
       DummyLifecycleOwner (Shown)
@@ -68,7 +60,7 @@ public class StatePrinterTest {
     root.attachToLifecycle(MyJourney().apply { attachToLifecycle(step) })
     step.attachToLifecycle(MySection())
     root.attachToLifecycle(MyJourney().apply { attachToLifecycle(MyLifecycleAwareThing()) })
-    root.create(context)
+    root.create()
 
     root.getLifecycleStateSnapshot() shouldBe """
       DummyLifecycleOwner (Created)

--- a/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/AttachFieldToLifecycleDelegateTest.kt
+++ b/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/AttachFieldToLifecycleDelegateTest.kt
@@ -1,19 +1,13 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Created
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Destroyed
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Resumed
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.beInstanceOf
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 internal class AttachFieldToLifecycleDelegateTest {
 
   private lateinit var parent: DummyLifecycleAwareComponent
@@ -32,13 +26,13 @@ internal class AttachFieldToLifecycleDelegateTest {
     val attachedChild by parent.attachFieldToLifecycle(child)
 
     attachedChild shouldBeSameInstanceAs child
-    child.currentState should beInstanceOf<Destroyed>()
+    child.currentState shouldBe Destroyed
 
-    parent.transitionToState(Resumed(getApplicationContext()))
-    child.currentState should beInstanceOf<Resumed>()
+    parent.transitionToState(Resumed)
+    child.currentState shouldBe Resumed
 
-    parent.transitionToState(Created(getApplicationContext()))
-    child.currentState should beInstanceOf<Created>()
+    parent.transitionToState(Created)
+    child.currentState shouldBe Created
   }
 
   @Test
@@ -46,13 +40,13 @@ internal class AttachFieldToLifecycleDelegateTest {
     val attachedCurrentState by parent.attachFieldToLifecycle(child) { it.currentState }
 
     attachedCurrentState shouldBeSameInstanceAs child.currentState
-    child.currentState should beInstanceOf<Destroyed>()
+    child.currentState shouldBe Destroyed
 
-    parent.transitionToState(Resumed(getApplicationContext()))
-    child.currentState should beInstanceOf<Resumed>()
+    parent.transitionToState(Resumed)
+    child.currentState shouldBe Resumed
 
-    parent.transitionToState(Created(getApplicationContext()))
-    child.currentState should beInstanceOf<Created>()
+    parent.transitionToState(Created)
+    child.currentState shouldBe Created
   }
 
   @Test
@@ -61,37 +55,37 @@ internal class AttachFieldToLifecycleDelegateTest {
 
     attachedChild = otherChild
     attachedChild shouldBeSameInstanceAs otherChild
-    otherChild.currentState should beInstanceOf<Destroyed>()
-    child.currentState should beInstanceOf<Destroyed>()
+    otherChild.currentState shouldBe Destroyed
+    child.currentState shouldBe Destroyed
 
-    parent.transitionToState(Resumed(getApplicationContext()))
-    otherChild.currentState should beInstanceOf<Resumed>()
-    child.currentState should beInstanceOf<Destroyed>()
+    parent.transitionToState(Resumed)
+    otherChild.currentState shouldBe Resumed
+    child.currentState shouldBe Destroyed
 
-    parent.transitionToState(Created(getApplicationContext()))
-    otherChild.currentState should beInstanceOf<Created>()
-    child.currentState should beInstanceOf<Destroyed>()
+    parent.transitionToState(Created)
+    otherChild.currentState shouldBe Created
+    child.currentState shouldBe Destroyed
   }
 
   @Test
   fun overrideValue_afterLifecycleEvents() {
     var attachedChild by parent.attachFieldToLifecycle(child)
 
-    otherChild.currentState should beInstanceOf<Destroyed>()
-    child.currentState should beInstanceOf<Destroyed>()
+    otherChild.currentState shouldBe Destroyed
+    child.currentState shouldBe Destroyed
 
-    parent.transitionToState(Resumed(getApplicationContext()))
-    otherChild.currentState should beInstanceOf<Destroyed>()
-    child.currentState should beInstanceOf<Resumed>()
+    parent.transitionToState(Resumed)
+    otherChild.currentState shouldBe Destroyed
+    child.currentState shouldBe Resumed
 
     attachedChild = otherChild
     attachedChild shouldBeSameInstanceAs otherChild
-    otherChild.currentState should beInstanceOf<Resumed>()
-    child.currentState should beInstanceOf<Destroyed>()
+    otherChild.currentState shouldBe Resumed
+    child.currentState shouldBe Destroyed
 
-    parent.transitionToState(Created(getApplicationContext()))
-    otherChild.currentState should beInstanceOf<Created>()
-    child.currentState should beInstanceOf<Destroyed>()
+    parent.transitionToState(Created)
+    otherChild.currentState shouldBe Created
+    child.currentState shouldBe Destroyed
   }
 
   @Test
@@ -101,20 +95,20 @@ internal class AttachFieldToLifecycleDelegateTest {
     overriddenProperty shouldBe 0
     overriddenProperty = 20
     overriddenProperty shouldBe 20
-    child.currentState should beInstanceOf<Destroyed>()
-    otherChild.currentState should beInstanceOf<Destroyed>()
+    child.currentState shouldBe Destroyed
+    otherChild.currentState shouldBe Destroyed
 
     child.dummyProperty = 30
     overriddenProperty shouldBe 20
 
-    parent.transitionToState(Resumed(getApplicationContext()))
+    parent.transitionToState(Resumed)
     overriddenProperty shouldBe 20
-    child.currentState should beInstanceOf<Destroyed>()
-    otherChild.currentState should beInstanceOf<Destroyed>()
+    child.currentState shouldBe Destroyed
+    otherChild.currentState shouldBe Destroyed
 
-    parent.transitionToState(Created(getApplicationContext()))
+    parent.transitionToState(Created)
     overriddenProperty shouldBe 20
-    child.currentState should beInstanceOf<Destroyed>()
-    otherChild.currentState should beInstanceOf<Destroyed>()
+    child.currentState shouldBe Destroyed
+    otherChild.currentState shouldBe Destroyed
   }
 }

--- a/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/AttachLateinitFieldToLifecycleDelegateTest.kt
+++ b/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/AttachLateinitFieldToLifecycleDelegateTest.kt
@@ -1,18 +1,13 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Created
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Destroyed
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Resumed
-import io.kotest.matchers.should
-import io.kotest.matchers.types.beInstanceOf
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 internal class AttachLateinitFieldToLifecycleDelegateTest {
 
   private lateinit var parent: DummyLifecycleAwareComponent
@@ -36,44 +31,44 @@ internal class AttachLateinitFieldToLifecycleDelegateTest {
   fun attachesToLifecycle() {
     var attachedChild by parent.attachLateinitFieldToLifecycle<DummyLifecycleAwareComponent>()
 
-    parent.transitionToState(Created(getApplicationContext()))
-    child.currentState should beInstanceOf<Destroyed>()
+    parent.transitionToState(Created)
+    child.currentState shouldBe Destroyed
 
     attachedChild = child
     attachedChild shouldBeSameInstanceAs child
-    child.currentState should beInstanceOf<Created>()
+    child.currentState shouldBe Created
 
-    parent.transitionToState(Resumed(getApplicationContext()))
-    child.currentState should beInstanceOf<Resumed>()
+    parent.transitionToState(Resumed)
+    child.currentState shouldBe Resumed
 
-    parent.transitionToState(Created(getApplicationContext()))
-    child.currentState should beInstanceOf<Created>()
+    parent.transitionToState(Created)
+    child.currentState shouldBe Created
   }
 
   @Test
   fun overrideValue() {
     var attachedChild by parent.attachLateinitFieldToLifecycle<DummyLifecycleAwareComponent>()
 
-    parent.transitionToState(Created(getApplicationContext()))
-    child.currentState should beInstanceOf<Destroyed>()
-    otherChild.currentState should beInstanceOf<Destroyed>()
+    parent.transitionToState(Created)
+    child.currentState shouldBe Destroyed
+    otherChild.currentState shouldBe Destroyed
 
     attachedChild = child
     attachedChild shouldBeSameInstanceAs child
-    child.currentState should beInstanceOf<Created>()
-    otherChild.currentState should beInstanceOf<Destroyed>()
+    child.currentState shouldBe Created
+    otherChild.currentState shouldBe Destroyed
 
     attachedChild = otherChild
     attachedChild shouldBeSameInstanceAs otherChild
-    child.currentState should beInstanceOf<Destroyed>()
-    otherChild.currentState should beInstanceOf<Created>()
+    child.currentState shouldBe Destroyed
+    otherChild.currentState shouldBe Created
 
-    parent.transitionToState(Resumed(getApplicationContext()))
-    child.currentState should beInstanceOf<Destroyed>()
-    otherChild.currentState should beInstanceOf<Resumed>()
+    parent.transitionToState(Resumed)
+    child.currentState shouldBe Destroyed
+    otherChild.currentState shouldBe Resumed
 
-    parent.transitionToState(Created(getApplicationContext()))
-    child.currentState should beInstanceOf<Destroyed>()
-    otherChild.currentState should beInstanceOf<Created>()
+    parent.transitionToState(Created)
+    child.currentState shouldBe Destroyed
+    otherChild.currentState shouldBe Created
   }
 }

--- a/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/CreateAndAttachFieldToLifecycleWhenShownDelegateTest.kt
+++ b/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/CreateAndAttachFieldToLifecycleWhenShownDelegateTest.kt
@@ -1,6 +1,5 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-import android.content.Context
 import android.widget.FrameLayout
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -17,9 +16,6 @@ public class CreateAndAttachFieldToLifecycleWhenShownDelegateTest {
   @Mock
   private lateinit var frameLayout: FrameLayout
 
-  @Mock
-  private lateinit var context: Context
-
   private lateinit var mockSession: AutoCloseable
 
   @Before
@@ -35,34 +31,34 @@ public class CreateAndAttachFieldToLifecycleWhenShownDelegateTest {
 
   @Test
   public fun wholeLifecycle() {
-    lifecycleView.create(context)
+    lifecycleView.create()
     lifecycleView.field.shouldBeNull()
 
-    lifecycleView.show(context)
+    lifecycleView.show()
     lifecycleView.field shouldBe frameLayout
 
-    lifecycleView.resume(context)
+    lifecycleView.resume()
     lifecycleView.field shouldBe frameLayout
 
-    lifecycleView.pause(context)
+    lifecycleView.pause()
     lifecycleView.field shouldBe frameLayout
 
-    lifecycleView.hide(context)
+    lifecycleView.hide()
     lifecycleView.field.shouldBeNull()
 
-    lifecycleView.destroy(context)
+    lifecycleView.destroy()
     lifecycleView.field.shouldBeNull()
   }
 
   @Test
   public fun onCreateView() {
-    lifecycleView.show(context)
+    lifecycleView.show()
     lifecycleView.field shouldBe frameLayout
   }
 
   @Test
   public fun onDestroyView() {
-    lifecycleView.hide(context)
+    lifecycleView.hide()
     lifecycleView.field.shouldBeNull()
   }
 }

--- a/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleRegistryTest.kt
+++ b/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleRegistryTest.kt
@@ -1,7 +1,5 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-import android.content.Context
-import androidx.test.core.app.ApplicationProvider
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Created
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Resumed
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Shown
@@ -12,16 +10,12 @@ import io.kotest.matchers.shouldBe
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.MockitoAnnotations.openMocks
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 internal class LifecycleRegistryTest {
 
   private val lifecycleRegistry = LifecycleRegistry()
-  private val context = ApplicationProvider.getApplicationContext<Context>()
 
   private lateinit var dummyLifecycleComponent1: DummyLifecycleComponent
   private lateinit var dummyLifecycleComponent2: DummyLifecycleComponent
@@ -57,12 +51,12 @@ internal class LifecycleRegistryTest {
 
   @Test(expected = IllegalStateException::class)
   fun throwsSinceWeAttachToLifecycleWhenAlreadyAttached() {
-    lifecycleRegistry.attachToLifecycle(lifecycleAware1, Created(context))
-    lifecycleRegistry.attachToLifecycle(lifecycleAware2, Created(context))
-    lifecycleRegistry.attachToLifecycle(lifecycleAware3, Created(context))
-    lifecycleRegistry.attachToLifecycle(lifecycleAware5, Created(context))
-    lifecycleRegistry.attachToLifecycle(lifecycleAware4, Created(context))
-    lifecycleRegistry.attachToLifecycle(lifecycleAware5, Created(context))
+    lifecycleRegistry.attachToLifecycle(lifecycleAware1, Created)
+    lifecycleRegistry.attachToLifecycle(lifecycleAware2, Created)
+    lifecycleRegistry.attachToLifecycle(lifecycleAware3, Created)
+    lifecycleRegistry.attachToLifecycle(lifecycleAware5, Created)
+    lifecycleRegistry.attachToLifecycle(lifecycleAware4, Created)
+    lifecycleRegistry.attachToLifecycle(lifecycleAware5, Created)
 
     lifecycleRegistry.listeners shouldContainExactly
       setOf(
@@ -76,9 +70,9 @@ internal class LifecycleRegistryTest {
 
   @Test
   fun attachToLifecycleWithMaxState() {
-    lifecycleRegistry.create(context)
-    lifecycleRegistry.show(context)
-    lifecycleRegistry.resume(context)
+    lifecycleRegistry.create()
+    lifecycleRegistry.show()
+    lifecycleRegistry.resume()
 
     lifecycleRegistry.attachToLifecycle(dummyLifecycleComponent1)
     lifecycleRegistry.attachToLifecycleWithMaxState(
@@ -86,69 +80,69 @@ internal class LifecycleRegistryTest {
       LifecycleLimit.CREATED
     )
 
-    dummyLifecycleComponent1.currentState shouldBe Resumed(context)
-    dummyLifecycleComponent2.currentState shouldBe Created(context)
+    dummyLifecycleComponent1.currentState shouldBe Resumed
+    dummyLifecycleComponent2.currentState shouldBe Created
   }
 
   @Test
   fun attachToLifecycleWithMaxState_notLimited() {
-    lifecycleRegistry.create(context)
+    lifecycleRegistry.create()
 
     lifecycleRegistry.attachToLifecycle(dummyLifecycleComponent1)
     lifecycleRegistry.attachToLifecycleWithMaxState(dummyLifecycleComponent2, LifecycleLimit.SHOWN)
 
-    dummyLifecycleComponent1.currentState shouldBe Created(context)
-    dummyLifecycleComponent2.currentState shouldBe Created(context)
+    dummyLifecycleComponent1.currentState shouldBe Created
+    dummyLifecycleComponent2.currentState shouldBe Created
   }
 
   @Test
   fun updateMaxStateForChild_beforeEvents() {
-    lifecycleRegistry.create(context)
+    lifecycleRegistry.create()
 
     lifecycleRegistry.attachToLifecycleWithMaxState(
       dummyLifecycleComponent1,
       LifecycleLimit.CREATED
     )
 
-    dummyLifecycleComponent1.currentState shouldBe Created(context)
+    dummyLifecycleComponent1.currentState shouldBe Created
 
     lifecycleRegistry.updateMaxState(dummyLifecycleComponent1, LifecycleLimit.SHOWN)
 
-    dummyLifecycleComponent1.currentState shouldBe Created(context)
+    dummyLifecycleComponent1.currentState shouldBe Created
 
-    lifecycleRegistry.show(context)
-    lifecycleRegistry.resume(context)
+    lifecycleRegistry.show()
+    lifecycleRegistry.resume()
 
-    dummyLifecycleComponent1.currentState shouldBe Shown(context)
+    dummyLifecycleComponent1.currentState shouldBe Shown
   }
 
   @Test
   fun updateMaxStateForChild_afterEvents() {
-    lifecycleRegistry.create(context)
-    lifecycleRegistry.show(context)
-    lifecycleRegistry.resume(context)
+    lifecycleRegistry.create()
+    lifecycleRegistry.show()
+    lifecycleRegistry.resume()
 
     lifecycleRegistry.attachToLifecycleWithMaxState(
       dummyLifecycleComponent1,
       LifecycleLimit.CREATED
     )
 
-    dummyLifecycleComponent1.currentState shouldBe Created(context)
+    dummyLifecycleComponent1.currentState shouldBe Created
 
     lifecycleRegistry.updateMaxState(dummyLifecycleComponent1, LifecycleLimit.SHOWN)
 
-    dummyLifecycleComponent1.currentState shouldBe Shown(context)
+    dummyLifecycleComponent1.currentState shouldBe Shown
 
     lifecycleRegistry.updateMaxState(dummyLifecycleComponent1, LifecycleLimit.CREATED)
 
-    dummyLifecycleComponent1.currentState shouldBe Created(context)
+    dummyLifecycleComponent1.currentState shouldBe Created
   }
 
   @Test
   fun onBackPressed_limited() {
-    lifecycleRegistry.create(context)
-    lifecycleRegistry.show(context)
-    lifecycleRegistry.resume(context)
+    lifecycleRegistry.create()
+    lifecycleRegistry.show()
+    lifecycleRegistry.resume()
 
     var unwantedBackPressed = false
     var wantedBackPressed = false
@@ -177,9 +171,9 @@ internal class LifecycleRegistryTest {
 
   @Test
   fun onBackPressed_notLimited() {
-    lifecycleRegistry.create(context)
-    lifecycleRegistry.show(context)
-    lifecycleRegistry.resume(context)
+    lifecycleRegistry.create()
+    lifecycleRegistry.show()
+    lifecycleRegistry.resume()
 
     var wantedBackPressed = false
     var unwantedBackPressed = false

--- a/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleStateTest.kt
+++ b/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleStateTest.kt
@@ -1,6 +1,5 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-import android.content.Context
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Created
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Destroyed
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Resumed
@@ -13,27 +12,15 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mock
 import org.mockito.MockitoAnnotations
 
 internal class LifecycleStateTest {
-
-  @Mock
-  private lateinit var context: Context
-  private lateinit var destroyed: Destroyed
-  private lateinit var created: Created
-  private lateinit var shown: Shown
-  private lateinit var resumed: Resumed
 
   private lateinit var mockSession: AutoCloseable
 
   @Before
   fun setUp() {
     mockSession = MockitoAnnotations.openMocks(this)
-    destroyed = Destroyed
-    created = Created(context)
-    shown = Shown(context)
-    resumed = Resumed(context)
   }
 
   @After
@@ -42,33 +29,25 @@ internal class LifecycleStateTest {
   }
 
   @Test
-  fun getEarlierOfCurrentState() {
-    destroyed.getEarlierOfCurrentState().shouldBeInstanceOf<Destroyed>()
-    created.getEarlierOfCurrentState().shouldBeInstanceOf<Created>()
-    shown.getEarlierOfCurrentState().shouldBeInstanceOf<Created>()
-    resumed.getEarlierOfCurrentState().shouldBeInstanceOf<Created>()
-  }
-
-  @Test
   fun getTheDirectionIShouldGoToGetTo() {
-    destroyed.getDirectionForMovement(destroyed) shouldBe NO_MOVEMENT
-    destroyed.getDirectionForMovement(created) shouldBe FORWARD
-    destroyed.getDirectionForMovement(shown) shouldBe FORWARD
-    destroyed.getDirectionForMovement(resumed) shouldBe FORWARD
+    Destroyed.getDirectionForMovement(Destroyed) shouldBe NO_MOVEMENT
+    Destroyed.getDirectionForMovement(Created) shouldBe FORWARD
+    Destroyed.getDirectionForMovement(Shown) shouldBe FORWARD
+    Destroyed.getDirectionForMovement(Resumed) shouldBe FORWARD
 
-    created.getDirectionForMovement(destroyed) shouldBe BACKWARDS
-    created.getDirectionForMovement(created) shouldBe NO_MOVEMENT
-    created.getDirectionForMovement(shown) shouldBe FORWARD
-    created.getDirectionForMovement(resumed) shouldBe FORWARD
+    Created.getDirectionForMovement(Destroyed) shouldBe BACKWARDS
+    Created.getDirectionForMovement(Created) shouldBe NO_MOVEMENT
+    Created.getDirectionForMovement(Shown) shouldBe FORWARD
+    Created.getDirectionForMovement(Resumed) shouldBe FORWARD
 
-    shown.getDirectionForMovement(destroyed) shouldBe BACKWARDS
-    shown.getDirectionForMovement(created) shouldBe BACKWARDS
-    shown.getDirectionForMovement(shown) shouldBe NO_MOVEMENT
-    shown.getDirectionForMovement(resumed) shouldBe FORWARD
+    Shown.getDirectionForMovement(Destroyed) shouldBe BACKWARDS
+    Shown.getDirectionForMovement(Created) shouldBe BACKWARDS
+    Shown.getDirectionForMovement(Shown) shouldBe NO_MOVEMENT
+    Shown.getDirectionForMovement(Resumed) shouldBe FORWARD
 
-    resumed.getDirectionForMovement(destroyed) shouldBe BACKWARDS
-    resumed.getDirectionForMovement(created) shouldBe BACKWARDS
-    resumed.getDirectionForMovement(shown) shouldBe BACKWARDS
-    resumed.getDirectionForMovement(resumed) shouldBe NO_MOVEMENT
+    Resumed.getDirectionForMovement(Destroyed) shouldBe BACKWARDS
+    Resumed.getDirectionForMovement(Created) shouldBe BACKWARDS
+    Resumed.getDirectionForMovement(Shown) shouldBe BACKWARDS
+    Resumed.getDirectionForMovement(Resumed) shouldBe NO_MOVEMENT
   }
 }

--- a/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleStateTest.kt
+++ b/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleStateTest.kt
@@ -8,7 +8,6 @@ import com.ryanmoelter.magellanx.core.lifecycle.LifecycleStateDirection.BACKWARD
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleStateDirection.FORWARD
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleStateDirection.NO_MOVEMENT
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.After
 import org.junit.Before
 import org.junit.Test

--- a/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleTransitionExtensionsTest.kt
+++ b/magellanx-core/src/test/java/com/ryanmoelter/magellanx/core/lifecycle/LifecycleTransitionExtensionsTest.kt
@@ -1,7 +1,5 @@
 package com.ryanmoelter.magellanx.core.lifecycle
 
-/* ktlint-disable import-ordering */ // `when` messes up IntelliJ's formatting
-import android.content.Context
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Created
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Destroyed
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Resumed
@@ -11,29 +9,17 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.InOrder
 import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.Mockito.inOrder
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.MockitoAnnotations.openMocks
-/* ktlint-enable import-ordering */
 
 internal class LifecycleTransitionExtensionsTest {
 
   @Mock
   lateinit var lifecycleAware: LifecycleAware
 
-  @Mock
-  lateinit var applicationContext: Context
-
-  @Mock
-  lateinit var context: Context
-
   private lateinit var inOrder: InOrder
-  private lateinit var destroyed: Destroyed
-  private lateinit var created: Created
-  private lateinit var shown: Shown
-  private lateinit var resumed: Resumed
 
   private lateinit var mockSession: AutoCloseable
 
@@ -42,13 +28,6 @@ internal class LifecycleTransitionExtensionsTest {
     mockSession = openMocks(this)
 
     inOrder = inOrder(lifecycleAware)
-    destroyed = Destroyed
-    created = Created(applicationContext)
-    shown = Shown(context)
-    resumed = Resumed(context)
-
-    `when`(context.applicationContext).thenReturn(applicationContext)
-    `when`(applicationContext.applicationContext).thenReturn(applicationContext)
   }
 
   @After
@@ -58,132 +37,132 @@ internal class LifecycleTransitionExtensionsTest {
 
   @Test
   fun transitionBetweenLifecycleStates_createToCreated() {
-    lifecycleAware.transition(created, created)
+    lifecycleAware.transition(Created, Created)
 
     verifyNoInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_createToShown() {
-    lifecycleAware.transition(created, shown)
+    lifecycleAware.transition(Created, Shown)
 
-    inOrder.verify(lifecycleAware).show(context)
+    inOrder.verify(lifecycleAware).show()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_createToResumed() {
-    lifecycleAware.transition(created, resumed)
+    lifecycleAware.transition(Created, Resumed)
 
-    inOrder.verify(lifecycleAware).show(context)
-    inOrder.verify(lifecycleAware).resume(context)
+    inOrder.verify(lifecycleAware).show()
+    inOrder.verify(lifecycleAware).resume()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_createToDestroy() {
-    lifecycleAware.transition(created, destroyed)
+    lifecycleAware.transition(Created, Destroyed)
 
-    inOrder.verify(lifecycleAware).destroy(applicationContext)
+    inOrder.verify(lifecycleAware).destroy()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_shownToCreated() {
-    lifecycleAware.transition(shown, created)
+    lifecycleAware.transition(Shown, Created)
 
-    inOrder.verify(lifecycleAware).hide(context)
+    inOrder.verify(lifecycleAware).hide()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_shownToShown() {
-    lifecycleAware.transition(shown, shown)
+    lifecycleAware.transition(Shown, Shown)
 
     verifyNoInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_shownToResumed() {
-    lifecycleAware.transition(shown, resumed)
+    lifecycleAware.transition(Shown, Resumed)
 
-    inOrder.verify(lifecycleAware).resume(context)
+    inOrder.verify(lifecycleAware).resume()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_shownToDestroy() {
-    lifecycleAware.transition(shown, destroyed)
+    lifecycleAware.transition(Shown, Destroyed)
 
-    inOrder.verify(lifecycleAware).hide(context)
-    inOrder.verify(lifecycleAware).destroy(applicationContext)
+    inOrder.verify(lifecycleAware).hide()
+    inOrder.verify(lifecycleAware).destroy()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_resumedToCreated() {
-    lifecycleAware.transition(resumed, created)
+    lifecycleAware.transition(Resumed, Created)
 
-    inOrder.verify(lifecycleAware).pause(context)
-    inOrder.verify(lifecycleAware).hide(context)
+    inOrder.verify(lifecycleAware).pause()
+    inOrder.verify(lifecycleAware).hide()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_resumedToShown() {
-    lifecycleAware.transition(resumed, shown)
+    lifecycleAware.transition(Resumed, Shown)
 
-    inOrder.verify(lifecycleAware).pause(context)
+    inOrder.verify(lifecycleAware).pause()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_resumedToResumed() {
-    lifecycleAware.transition(resumed, resumed)
+    lifecycleAware.transition(Resumed, Resumed)
 
     verifyNoInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_resumedToDestroy() {
-    lifecycleAware.transition(resumed, destroyed)
+    lifecycleAware.transition(Resumed, Destroyed)
 
-    inOrder.verify(lifecycleAware).pause(context)
-    inOrder.verify(lifecycleAware).hide(context)
-    inOrder.verify(lifecycleAware).destroy(applicationContext)
+    inOrder.verify(lifecycleAware).pause()
+    inOrder.verify(lifecycleAware).hide()
+    inOrder.verify(lifecycleAware).destroy()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_destroyedToCreated() {
-    lifecycleAware.transition(destroyed, created)
+    lifecycleAware.transition(Destroyed, Created)
 
-    inOrder.verify(lifecycleAware).create(applicationContext)
+    inOrder.verify(lifecycleAware).create()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_destroyedToShown() {
-    lifecycleAware.transition(destroyed, shown)
+    lifecycleAware.transition(Destroyed, Shown)
 
-    inOrder.verify(lifecycleAware).create(applicationContext)
-    inOrder.verify(lifecycleAware).show(context)
+    inOrder.verify(lifecycleAware).create()
+    inOrder.verify(lifecycleAware).show()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_destroyedToResumed() {
-    lifecycleAware.transition(destroyed, resumed)
+    lifecycleAware.transition(Destroyed, Resumed)
 
-    inOrder.verify(lifecycleAware).create(applicationContext)
-    inOrder.verify(lifecycleAware).show(context)
-    inOrder.verify(lifecycleAware).resume(context)
+    inOrder.verify(lifecycleAware).create()
+    inOrder.verify(lifecycleAware).show()
+    inOrder.verify(lifecycleAware).resume()
     verifyNoMoreInteractions(lifecycleAware)
   }
 
   @Test
   fun transitionBetweenLifecycleStates_destroyedToDestroy() {
-    lifecycleAware.transition(destroyed, destroyed)
+    lifecycleAware.transition(Destroyed, Destroyed)
 
     verifyNoInteractions(lifecycleAware)
   }

--- a/magellanx-test/src/main/java/com/ryanmoelter/magellanx/test/FakeComposeNavigator.kt
+++ b/magellanx-test/src/main/java/com/ryanmoelter/magellanx/test/FakeComposeNavigator.kt
@@ -40,7 +40,7 @@ public class FakeComposeNavigator : ComposeNavigator() {
     backStack = backStackOperation(backStack)
   }
 
-  public override fun onDestroy(context: Context) {
+  public override fun onDestroy() {
     clear()
   }
 }

--- a/magellanx-test/src/main/java/com/ryanmoelter/magellanx/test/FakeComposeNavigator.kt
+++ b/magellanx-test/src/main/java/com/ryanmoelter/magellanx/test/FakeComposeNavigator.kt
@@ -1,6 +1,5 @@
 package com.ryanmoelter.magellanx.test
 
-import android.content.Context
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.runtime.Composable
 import com.ryanmoelter.magellanx.compose.navigation.ComposeNavigationEvent

--- a/magellanx-test/src/test/java/com/ryanmoelter/magellanx/test/FakeLinearNavigatorTest.kt
+++ b/magellanx-test/src/test/java/com/ryanmoelter/magellanx/test/FakeLinearNavigatorTest.kt
@@ -1,7 +1,5 @@
 package com.ryanmoelter.magellanx.test
 
-import android.content.Context
-import androidx.compose.animation.ExperimentalAnimationApi
 import com.ryanmoelter.magellanx.compose.navigation.ComposeNavigationEvent
 import com.ryanmoelter.magellanx.compose.navigation.Direction
 import com.ryanmoelter.magellanx.compose.transitions.defaultTransition
@@ -16,21 +14,16 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import org.junit.Before
 import org.junit.Test
-import org.mockito.Mock
-import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations.initMocks
 
-@OptIn(ExperimentalAnimationApi::class)
 public class FakeLinearNavigatorTest {
 
   private lateinit var navigator: FakeComposeNavigator
-  @Mock internal lateinit var context: Context
 
   @Before
   public fun setUp() {
     initMocks(this)
     navigator = FakeComposeNavigator()
-    `when`(context.applicationContext).thenReturn(context)
   }
 
   @Test
@@ -111,8 +104,8 @@ public class FakeLinearNavigatorTest {
   @Test
   public fun destroy() {
     navigator.backStack = listOf(ComposeNavigationEvent(TestNavigable(), defaultTransition))
-    navigator.transitionToState(LifecycleState.Created(context))
-    navigator.destroy(context)
+    navigator.transitionToState(LifecycleState.Created)
+    navigator.destroy()
     navigator.backStack.shouldBeEmpty()
     navigator.currentNavigable.shouldBeNull()
   }


### PR DESCRIPTION
The more I think about this, the more it shouldn't be in the core library. We can provide a `LifecycleAware` `ContextProvider` instead (maybe in a different PR).