### PR TITLE
Exclude Kotlin from renovate auto-merge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,11 +18,17 @@
         "pin",
         "digest"
       ],
+      "excludePackageNames": [
+        "org.jetbrains.kotlin:kotlin-gradle-plugin"
+      ],
       "automerge": true
     },
     {
       "matchUpdateTypes": [
         "patch"
+      ],
+      "excludePackageNames": [
+        "org.jetbrains.kotlin:kotlin-gradle-plugin"
       ],
       "groupName": "Patch dependency updates",
       "automerge": true


### PR DESCRIPTION
Kotlin doesn't follow semantic versioning, so we have to exclude it from auto-merge and patch dependency grouping