### PR TITLE
Fix group name, attempt to fix sources publishing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-GROUP=com.ryanmoelter
+GROUP=com.ryanmoelter.magellanx
 VERSION_NAME=0.5.1-SNAPSHOT
 
 POM_DESCRIPTION=A simple, flexible, and practical navigation library for android using Jetpack Compose

--- a/magellanx-compose/build.gradle.kts
+++ b/magellanx-compose/build.gradle.kts
@@ -47,8 +47,7 @@ android {
   }
 
   publishing {
-    multipleVariants {
-      allVariants()
+    singleVariant("release") {
       withJavadocJar()
       withSourcesJar()
     }
@@ -103,14 +102,14 @@ dependencies {
   testImplementation(libs.robolectric)
   testImplementation(libs.androidx.test.core)
   testImplementation(libs.androidx.test.core.ktx)
-  androidTestImplementation("junit:junit:4.13.2")
-  androidTestImplementation("androidx.test.ext:junit:1.1.5")
-  androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+  androidTestImplementation(libs.junit)
+  androidTestImplementation(libs.androidx.test.ext.junit)
+  androidTestImplementation(libs.espresso.core)
 }
 
 publishing {
   publications {
-    register<MavenPublication>("default") {
+    register<MavenPublication>("release") {
       groupId = extra["GROUP"] as String
       artifactId = extra["POM_ARTIFACT_ID"] as String
       version = extra["VERSION_NAME"] as String

--- a/magellanx-core/build.gradle.kts
+++ b/magellanx-core/build.gradle.kts
@@ -41,8 +41,7 @@ android {
   }
 
   publishing {
-    multipleVariants {
-      allVariants()
+    singleVariant("release") {
       withJavadocJar()
       withSourcesJar()
     }
@@ -72,14 +71,14 @@ dependencies {
   testImplementation(libs.kotest.assertions.core)
   testImplementation(libs.androidx.test.core)
   testImplementation(libs.androidx.test.core.ktx)
-  testImplementation("junit:junit:4.13.2")
-  androidTestImplementation("androidx.test.ext:junit:1.1.5")
-  androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+  testImplementation(libs.junit)
+  androidTestImplementation(libs.androidx.test.ext.junit)
+  androidTestImplementation(libs.espresso.core)
 }
 
 publishing {
   publications {
-    register<MavenPublication>("default") {
+    register<MavenPublication>("release") {
       groupId = extra["GROUP"] as String
       artifactId = extra["POM_ARTIFACT_ID"] as String
       version = extra["VERSION_NAME"] as String

--- a/magellanx-test/build.gradle.kts
+++ b/magellanx-test/build.gradle.kts
@@ -33,8 +33,7 @@ android {
   }
 
   publishing {
-    multipleVariants {
-      allVariants()
+    singleVariant("release") {
       withJavadocJar()
       withSourcesJar()
     }
@@ -42,14 +41,15 @@ android {
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
-  kotlinOptions.freeCompilerArgs = if (!name.contains("UnitTest")) {
-    listOf(
-      "-Xexplicit-api=strict",
-      "-opt-in=kotlin.RequiresOptIn"
-    )
-  } else {
-    listOf("-opt-in=kotlin.RequiresOptIn")
-  }
+  kotlinOptions.freeCompilerArgs =
+    if (!name.contains("UnitTest")) {
+      listOf(
+        "-Xexplicit-api=strict",
+        "-opt-in=kotlin.RequiresOptIn",
+      )
+    } else {
+      listOf("-opt-in=kotlin.RequiresOptIn")
+    }
   kotlinOptions.allWarningsAsErrors = true
   kotlinOptions.jvmTarget = "1.8"
 }
@@ -75,7 +75,7 @@ dependencies {
 
 publishing {
   publications {
-    register<MavenPublication>("default") {
+    register<MavenPublication>("release") {
       groupId = extra["GROUP"] as String
       artifactId = extra["POM_ARTIFACT_ID"] as String
       version = extra["VERSION_NAME"] as String
@@ -114,4 +114,3 @@ publishing {
     }
   }
 }
-


### PR DESCRIPTION
- Make group name match what's published on Jitpack. This makes it easier to use `publishToMavenLocal` for local testing.
- Attempt to fix sources publishing by tweaking gradle config.