### PR TITLE
Show children in previews without using interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,6 @@ class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     // ...
     setContentNavigable(rootStep)  // Add rootStep to the lifecycle and UI
-    onBackPressedDispatcher.addCallback {  // Handle back navigation (eventually won't be necessary)
-      if (!rootStep.backPressed()) {
-        this@MainActivity.finish()
-      }
-    }
     // ...
   }
 }

--- a/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ActivityLifecycleComposeAdapter.kt
+++ b/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ActivityLifecycleComposeAdapter.kt
@@ -46,6 +46,10 @@ public class ActivityLifecycleComposeAdapter(
   }
 }
 
+/**
+ * Attach [navigable] as the root [Navigable] for this Activity. Sets the UI, attaches the
+ * lifecycle, and handles back navigation. Should be called in [Activity.onCreate].
+ */
 public fun ComponentActivity.setContentNavigable(navigable: Navigable<@Composable () -> Unit>) {
   if (navigable is LifecycleOwner && navigable.currentState == Destroyed) {
     navigable.create()
@@ -56,7 +60,9 @@ public fun ComponentActivity.setContentNavigable(navigable: Navigable<@Composabl
   }
   val lifecycleAdapter = ActivityLifecycleComposeAdapter(navigable, this)
   navigable.attachAndAddToStaticMap(lifecycleAdapter, lifecycle)
+
   setContent { navigable.Content() }
+
   onBackPressedDispatcher.addCallback {
     if (!navigable.backPressed()) {
       this@setContentNavigable.finish()

--- a/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ActivityLifecycleComposeAdapter.kt
+++ b/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ActivityLifecycleComposeAdapter.kt
@@ -2,6 +2,7 @@ package com.ryanmoelter.magellanx.compose
 
 import android.app.Activity
 import androidx.activity.ComponentActivity
+import androidx.activity.addCallback
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -56,6 +57,11 @@ public fun ComponentActivity.setContentNavigable(navigable: Navigable<@Composabl
   val lifecycleAdapter = ActivityLifecycleComposeAdapter(navigable, this)
   navigable.attachAndAddToStaticMap(lifecycleAdapter, lifecycle)
   setContent { navigable.Content() }
+  onBackPressedDispatcher.addCallback {
+    if (!navigable.backPressed()) {
+      this@setContentNavigable.finish()
+    }
+  }
 }
 
 private fun Navigable<@Composable () -> Unit>.attachAndAddToStaticMap(

--- a/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ComposeExtensions.kt
+++ b/magellanx-compose/src/main/java/com/ryanmoelter/magellanx/compose/ComposeExtensions.kt
@@ -4,13 +4,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.ryanmoelter.magellanx.core.Displayable
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleOwner
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Resumed
 import com.ryanmoelter.magellanx.core.lifecycle.LifecycleState.Started
-import kotlinx.coroutines.flow.map
 
 @Composable
 @Suppress("ktlint:standard:function-naming")
@@ -30,12 +28,8 @@ public fun Displayable(
 @Composable
 @Suppress("ktlint:standard:function-naming")
 public fun LifecycleOwner.WhenStarted(content: @Composable () -> Unit) {
-  val isStartedFlow =
-    remember {
-      currentStateFlow
-        .map { lifecycleState -> lifecycleState >= Started }
-    }
-  val isStarted by isStartedFlow.collectAsState(false)
+  val currentState by currentStateFlow.collectAsState()
+  val isStarted = currentState >= Started
   if (isStarted) {
     content()
   }
@@ -44,12 +38,8 @@ public fun LifecycleOwner.WhenStarted(content: @Composable () -> Unit) {
 @Composable
 @Suppress("ktlint:standard:function-naming")
 public fun LifecycleOwner.WhenResumed(content: @Composable () -> Unit) {
-  val isResumedFlow =
-    remember {
-      currentStateFlow
-        .map { lifecycleState -> lifecycleState >= Resumed }
-    }
-  val isResumed by isResumedFlow.collectAsState(false)
+  val currentState by currentStateFlow.collectAsState()
+  val isResumed = currentState >= Resumed
   if (isResumed) {
     content()
   }

--- a/magellanx-sample-app/src/main/java/com/ryanmoelter/magellanx/doggos/MainActivity.kt
+++ b/magellanx-sample-app/src/main/java/com/ryanmoelter/magellanx/doggos/MainActivity.kt
@@ -14,10 +14,4 @@ class MainActivity : ComponentActivity() {
 
     setContentNavigable(rootJourney)
   }
-
-  override fun onBackPressed() {
-    if (!rootJourney.backPressed()) {
-      super.onBackPressed()
-    }
-  }
 }


### PR DESCRIPTION
- Default to actual values instead of "false"/"null"
  - Navigator → `currentNavigable`
  - Extensions → `WhenStarted`/`WhenResumed` (used in `ComposeSection`/`Step`/`Journey`)

### Sneaky fixes
- BREAKING: Attach back listener automatically, in `setContentNavigable()`
- Fix rare crash related to removing child `Navigable`s from the composition