### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.0 (BREAKING)
+- **Breaking: Automatically attach `onBackPressedDispatcher` in `setContentNavigable()`.** Now, the only code required to attach Magellan to your `MainActivity` is `setContentNavigable()`.
+- Make compose previews work without using interactive mode for `Journey`s and nested `Step`s
+- Bump target and compile SDK level from 34 to 35
+- Update dependencies, including to Kotlin `2.1.0` and Compose BOM to `2024.12.01`
+
 ## 0.5.2
 - Update dependencies, including to Kotlin `1.9.23`, Compose BOM to `2024.03.00`, Compose Compiler to `1.5.11`.
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,8 @@ dependencies {
 }
 ```
 
-### Add to `dependencies` block
-
 <details>
-  <summary>Add to <code>dependencies</code> block instead</summary>
+  <summary><h3>Add to <code>dependencies</code> block (without version catalogs)</h3></summary>
 
 If you don't want to use version catalogs, you can add the dependencies you need directly in your
 `dependencies` block:
@@ -93,16 +91,15 @@ implementation("com.github.ryanmoelter.magellanx:magellanx-core:0.5.2")
 
 </details>
 
-### Dependency versions
-
 <details>
-  <summary>Dependencies' versions for different Magellan X versions</summary>
+  <summary><h3>Dependency versions</h3></summary>
 
 Magellan X uses the following dependencies, and since `0.2.0` is using
 [the compose bill of materials (BOM)](https://developer.android.com/jetpack/compose/setup#using-the-bom).
 
 | Magellan X version | Kotlin version | Compose compiler version | Compose BOM  | Tested compatible compose versions |
 |--------------------|----------------|--------------------------|--------------|------------------------------------|
+| `0.6.0`            | `2.1.0`        | Bundled with Kotlin      | `2024.12.01` | `1.6.4`                            |
 | `0.5.2`            | `1.9.23`       | `1.5.11`                 | `2024.03.00` | `1.6.4`                            |
 | `0.5.1`            | `1.9.22`       | `1.5.10`                 | `2024.02.02` | `1.6.3`                            |
 | `0.5.0`            | `1.9.22`       | `1.5.10`                 | `2024.02.01` | `1.6.2`                            |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,18 +1,29 @@
 # Releasing
 
-1. Change the version in `gradle.properties` to a non-SNAPSHOT version.
-2. Update the `CHANGELOG.md` for the impending release.
-3. Update the `README.md` with the new version.
-4. `git commit -am "Release X.Y.Z"` (where X.Y.Z is the new version)
-5. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
-6. Update the `gradle.properties` to the next SNAPSHOT version (increment patch by 1, e.g. `1.0.0` → `1.0.1-SNAPSHOT`).
-7. `git commit -am "Prepare next development version"`
-8. `git push && git push --tags`
-9. Visit [the GitHub releases page](https://github.com/ryanmoelter/magellanx/releases) and create a new release, copying the changelog from `CHANGELOG.md`.
-10. Visit [the Jitpack site](https://jitpack.io/#com.ryanmoelter/magellanx) and check that the new release shows up
+1. Change the version in `gradle.properties` to a non-SNAPSHOT version
+2. Update the `CHANGELOG.md` for the new release
+3. Update the `README.md` with the new version
+4. `git checkout -b release-X.Y.Z` (where X.Y.Z is the new version)
+5. `git commit -am "Release X.Y.Z"`
+6. `git push`; make a PR; merge PR
+7. `git checkout main && git pull`
+8. `git tag -a X.Y.Z -m "Version X.Y.Z"` (where X.Y.Z is the new version)
+9. Update the `gradle.properties` to the next SNAPSHOT version (increment patch by 1, e.g. `1.0.0` → `1.0.1-SNAPSHOT`)
+10. `git commit -am "Prepare next development version"`
+11. `git push && git push --tags`
+12. Visit [the GitHub releases page](https://github.com/ryanmoelter/magellanx/releases) and create a new release, copying the changelog from `CHANGELOG.md`
+13. Visit [the Jitpack site](https://jitpack.io/#com.ryanmoelter/magellanx) and check that the new release shows up
 
 ## Publish to local maven repo
 
 1. Run `./gradlew publishToMavenLocal`.
 2. In the other project, add `mavenLocal()` as a repository (likely in `allProjects.repositories` of the root `build.gradle` file).
 3. Update `com.ryanmoelter.magellanx:magellanx-compose:X.Y.Z` to `com.ryanmoelter.magellanx:magellanx-compose:SNAPSHOT_VERSION`, where `SNAPSHOT_VERSION` is the `VERSION_NAME` defined in this project's `./gradle.properties`.
+
+## Publish from a PR
+
+[the Jitpack site](https://jitpack.io/#com.ryanmoelter/magellanx) provides builds for each branch. They take a while to build, so for quick iteration I recommend using `mavenLocal` as shown above.
+
+1. Push a branch to this repo
+2. Update your dependency version to `{branch-name}-SNAPSHOT`, where `{branch-name}` is your branch's name
+3. Wait for Jitpack to build, which might take ~10 minutes

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.ryanmoelter.magellanx
-VERSION_NAME=0.5.3-SNAPSHOT
+VERSION_NAME=0.6.0
 
 POM_DESCRIPTION=A simple, flexible, and practical navigation library for android using Jetpack Compose
 


### PR DESCRIPTION
## 0.6.0 (BREAKING)
- **Breaking: Automatically attach `onBackPressedDispatcher` in `setContentNavigable()`.** Now, the only code required to attach Magellan to your `MainActivity` is `setContentNavigable()`.
- Make compose previews work without using interactive mode for `Journey`s and nested `Step`s
- Bump target and compile SDK level from 34 to 35
- Update dependencies, including to Kotlin `2.1.0` and Compose BOM to `2024.12.01`